### PR TITLE
Added fix for new Java versioning convention

### DIFF
--- a/ptolemy/gui/MacOSXAdapter.java
+++ b/ptolemy/gui/MacOSXAdapter.java
@@ -180,7 +180,10 @@ public class MacOSXAdapter implements InvocationHandler {
         // to use a different technique.
         String version = System.getProperty("java.version");
         int dot = version.indexOf(".");
-        int majorVersion = Integer.parseInt(version.substring(0, dot));
+ 
+        int majorVersion = (dot == -1) ? Integer.parseInt(version)
+                                       : Integer.parseInt(version.substring(0, dot));
+        
         if (majorVersion >= 9) {
             // Desktop class exists in Java 8, so this will compile.
             // But the methods we need to not exist, so we use reflection for those.


### PR DESCRIPTION
This fix prevents from getting errors while running code with major releases of Java. Since release 9, Java has this strange convention of setting JVMs version to # and then, with further releases it becomes #.#.#.

It means, that with each new, major release, there is an error while evaluating this one:

`Integer.parseInt(version.substring(0, dot));`